### PR TITLE
GDT-83 Redirect improvements after the payment is canceled

### DIFF
--- a/app/Resources/views/cancel.html.twig
+++ b/app/Resources/views/cancel.html.twig
@@ -1,0 +1,16 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    <div id="wrapper">
+        <div id="container">
+            <div id="welcome">
+                <h1><span>Welcome to Payments Hub Sandbox.</span></h1>
+            </div>
+            {% if app.request.get('token') %}
+                <div style="color: #ff8888">Purchase {{ app.request.get('token') }} has been canceled!</div>
+            {% else %}
+                <div style="color: #ff8888">Purchase has been canceled!</div>
+            {%  endif %}
+        </div>
+    </div>
+{% endblock %}

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -6,6 +6,10 @@ ph_core_thankyou:
     path:     /thank-you
     defaults: { _controller: PHCoreBundle:Sandbox:thankyou }
 
+ph_core_cancel:
+    path:     /cancel
+    defaults: { _controller: PHCoreBundle:Sandbox:cancel }
+
 ph_payum_capture:
     resource: "@PayumBundle/Resources/config/routing/all.xml"
 

--- a/src/PH/Bundle/CoreBundle/Controller/SandboxController.php
+++ b/src/PH/Bundle/CoreBundle/Controller/SandboxController.php
@@ -25,4 +25,11 @@ class SandboxController extends Controller
             'token' => $request->query->has('token') ? $request->query->has('token') : '',
         ]);
     }
+
+    public function cancelAction(Request $request)
+    {
+        return $this->render('cancel.html.twig', [
+            'token' => $request->query->has('token') ? $request->query->has('token') : '',
+        ]);
+    }
 }

--- a/src/PH/Bundle/CoreBundle/Resources/config/routing_public_api.yml
+++ b/src/PH/Bundle/CoreBundle/Resources/config/routing_public_api.yml
@@ -60,7 +60,6 @@ ph_public_api_payum_order_pay:
                 route: ph_public_api_payum_order_after_pay
                 parameters:
                     version: $version
-                    thankyou: $thankyou
 
 ph_public_api_payum_order_after_pay:
     path: /checkouts/after-pay/

--- a/src/PH/Bundle/PayumBundle/Action/ResolveNextRouteAction.php
+++ b/src/PH/Bundle/PayumBundle/Action/ResolveNextRouteAction.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PH\Bundle\PayumBundle\Action;
+
+use Payum\Core\Action\ActionInterface;
+use PH\Bundle\PayumBundle\Request\ResolveNextRoute;
+use PH\Component\Core\Model\PaymentInterface;
+
+final class ResolveNextRouteAction implements ActionInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @param ResolveNextRoute $request
+     */
+    public function execute($request): void
+    {
+        /** @var PaymentInterface $payment */
+        $payment = $request->getFirstModel();
+
+        if (
+            $payment->getState() === PaymentInterface::STATE_COMPLETED ||
+            $payment->getState() === PaymentInterface::STATE_AUTHORIZED ||
+            $payment->getState() === PaymentInterface::STATE_PROCESSING
+        ) {
+            $request->setRouteName('ph_core_thankyou');
+            $request->setRouteParameters(['token' => $payment->getOrder()->getTokenValue()]);
+
+            return;
+        }
+
+        $request->setRouteName('ph_core_cancel');
+        $request->setRouteParameters(['token' => $payment->getOrder()->getTokenValue()]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($request): bool
+    {
+        return
+            $request instanceof ResolveNextRoute &&
+            $request->getFirstModel() instanceof PaymentInterface
+        ;
+    }
+}

--- a/src/PH/Bundle/PayumBundle/Factory/ResolveNextRouteFactory.php
+++ b/src/PH/Bundle/PayumBundle/Factory/ResolveNextRouteFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PH\Bundle\PayumBundle\Factory;
+
+use PH\Bundle\PayumBundle\Request\ResolveNextRoute;
+use PH\Bundle\PayumBundle\Request\ResolveNextRouteInterface;
+
+final class ResolveNextRouteFactory implements ResolveNextRouteFactoryInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createNewWithModel($model): ResolveNextRouteInterface
+    {
+        return new ResolveNextRoute($model);
+    }
+}

--- a/src/PH/Bundle/PayumBundle/Factory/ResolveNextRouteFactoryInterface.php
+++ b/src/PH/Bundle/PayumBundle/Factory/ResolveNextRouteFactoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PH\Bundle\PayumBundle\Factory;
+
+use PH\Bundle\PayumBundle\Request\ResolveNextRouteInterface;
+
+interface ResolveNextRouteFactoryInterface
+{
+    /**
+     * @param $model
+     *
+     * @return ResolveNextRouteInterface
+     */
+    public function createNewWithModel($model): ResolveNextRouteInterface;
+}

--- a/src/PH/Bundle/PayumBundle/Request/ResolveNextRoute.php
+++ b/src/PH/Bundle/PayumBundle/Request/ResolveNextRoute.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PH\Bundle\PayumBundle\Request;
+
+use Payum\Core\Request\Generic;
+
+/**
+ * @author Arkadiusz Krakowiak <arkadiusz.krakowiak@lakion.com>
+ */
+class ResolveNextRoute extends Generic implements ResolveNextRouteInterface
+{
+    /**
+     * @var string
+     */
+    private $routeName;
+
+    /**
+     * @var array
+     */
+    private $routeParameters = [];
+
+    public function getRouteName(): ?string
+    {
+        return $this->routeName;
+    }
+
+    public function setRouteName(string $routeName): void
+    {
+        $this->routeName = $routeName;
+    }
+
+    public function getRouteParameters(): array
+    {
+        return $this->routeParameters;
+    }
+
+    public function setRouteParameters(array $parameters): void
+    {
+        $this->routeParameters = $parameters;
+    }
+}

--- a/src/PH/Bundle/PayumBundle/Request/ResolveNextRouteInterface.php
+++ b/src/PH/Bundle/PayumBundle/Request/ResolveNextRouteInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PH\Bundle\PayumBundle\Request;
+
+interface ResolveNextRouteInterface
+{
+    public function getRouteName(): ?string;
+
+    public function setRouteName(string $routeName): void;
+
+    public function getRouteParameters(): array;
+
+    public function setRouteParameters(array $parameters): void;
+}

--- a/src/PH/Bundle/PayumBundle/Resources/config/actions.yml
+++ b/src/PH/Bundle/PayumBundle/Resources/config/actions.yml
@@ -8,6 +8,11 @@ services:
         tags:
             - { name: "payum.action", all: true, alias: "sylius.capture_payment"}
 
+    ph.payum_action.resolve_next_route:
+        class: PH\Bundle\PayumBundle\Action\ResolveNextRouteAction
+        tags:
+            - { name: "payum.action", all: true, alias: "ph.resolve_next_route"}
+
     # Paypal
     ph.payum_action.paypal_express_checkout.convert_payment:
         class: PH\Bundle\PayumBundle\Action\Paypal\ExpressCheckout\ConvertPaymentAction

--- a/src/PH/Bundle/PayumBundle/Resources/config/services.yml
+++ b/src/PH/Bundle/PayumBundle/Resources/config/services.yml
@@ -9,6 +9,7 @@ services:
           - '@sylius.resource_controller.view_handler'
           - '@router'
           - '@sylius.repository.payment'
+          - '@ph.payum.factory.resolve_next_route'
 
     ph.payum.mollie.factory:
         class: Payum\Core\Bridge\Symfony\Builder\GatewayFactoryBuilder
@@ -21,3 +22,6 @@ services:
         arguments: [Sourcefabric\Payum\Mbe4\Mbe4GatewayFactory]
         tags:
             - { name: payum.gateway_factory_builder, factory: mbe4 }
+
+    ph.payum.factory.resolve_next_route:
+        class: PH\Bundle\PayumBundle\Factory\ResolveNextRouteFactory


### PR DESCRIPTION
Added an extra action which helps to redirect user accordingly to the payment status. 
If the payment has been cancelled by the user, the user will be redirected to `cancel` route and payment will be cancelled, if the payment is successful then the user is redirected to the `thank-you` route.