### PR TITLE
Added exceptions handling

### DIFF
--- a/src/PH/Bundle/PayumBundle/DependencyInjection/PHPayumExtension.php
+++ b/src/PH/Bundle/PayumBundle/DependencyInjection/PHPayumExtension.php
@@ -30,6 +30,7 @@ final class PHPayumExtension extends AbstractResourceExtension
         $loader->load('services.yml');
         $loader->load('actions.yml');
         $loader->load('forms.yml');
+        $loader->load('extensions.yml');
 
         $container->setParameter('ph.payum.redirect.thank_you_url', $config['thank_you_url']);
         $container->setParameter('ph.payum.redirect.cancel_url', $config['cancel_url']);

--- a/src/PH/Bundle/PayumBundle/Extension/ExceptionExtension.php
+++ b/src/PH/Bundle/PayumBundle/Extension/ExceptionExtension.php
@@ -38,12 +38,11 @@ final class ExceptionExtension implements ExtensionInterface
      */
     public function onPostExecute(Context $context)
     {
-        if (null === ($exception = $context->getException())) {
+        if (null === $context->getException()) {
             return;
         }
 
         $renderTemplate = new RenderTemplate($this->templateName);
-
         $context->getGateway()->execute($renderTemplate);
 
         throw new HttpResponse(new Response($renderTemplate->getResult(), 200));

--- a/src/PH/Bundle/PayumBundle/Extension/ExceptionExtension.php
+++ b/src/PH/Bundle/PayumBundle/Extension/ExceptionExtension.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PH\Bundle\PayumBundle\Extension;
+
+use Payum\Core\Bridge\Symfony\Reply\HttpResponse;
+use Payum\Core\Extension\Context;
+use Payum\Core\Extension\ExtensionInterface;
+use Payum\Core\Request\RenderTemplate;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ExceptionExtension implements ExtensionInterface
+{
+    private $templateName;
+
+    public function __construct(string $templateName)
+    {
+        $this->templateName = $templateName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onPreExecute(Context $context)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onExecute(Context $context)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onPostExecute(Context $context)
+    {
+        if (null === ($exception = $context->getException())) {
+            return;
+        }
+
+        $renderTemplate = new RenderTemplate($this->templateName);
+
+        $context->getGateway()->execute($renderTemplate);
+
+        throw new HttpResponse(new Response($renderTemplate->getResult(), 200));
+    }
+}

--- a/src/PH/Bundle/PayumBundle/Resources/config/extensions.yml
+++ b/src/PH/Bundle/PayumBundle/Resources/config/extensions.yml
@@ -1,0 +1,10 @@
+parameters:
+    payum.template.exception: '@@PHPayum/exception.html.twig'
+
+services:
+    ph.payum_extension.exception:
+        class: PH\Bundle\PayumBundle\Extension\ExceptionExtension
+        arguments:
+            - '%payum.template.exception%'
+        tags:
+            - { name: "payum.extension", all: true, prepend: true }

--- a/src/PH/Bundle/PayumBundle/Resources/views/exception.html.twig
+++ b/src/PH/Bundle/PayumBundle/Resources/views/exception.html.twig
@@ -1,0 +1,1 @@
+<h3>An error occured, please try again later.</h3>


### PR DESCRIPTION
A template is rendered when an exception is thrown, instead of returning 500 status code.

Default template is located at `src/PH/Bundle/PayumBundle/Resources/views/exception.html.twig`

It can be switched to some custom one by setting a parameter `payum.template.exception` in `parameters.yml` file.
