### PR TITLE
Remove current date from start date field

### DIFF
--- a/app/Resources/views/index.html.twig
+++ b/app/Resources/views/index.html.twig
@@ -83,9 +83,7 @@
                 currency = $form.find( "select[name='ph_subscription[currencyCode]']" ).val(),
                 amount = $form.find( "input[name='ph_subscription[amount]']" ).val(),
                 interval = $form.find( "select[name='ph_subscription[interval]']" ).val(),
-                startMonth = $form.find( "select[name='ph_subscription[startDate][month]']" ).val(),
-                startDay = $form.find( "select[name='ph_subscription[startDate][day]']" ).val(),
-                startYear = $form.find( "select[name='ph_subscription[startDate][year]']" ).val(),
+                startDate = $form.find( "select[name='ph_subscription[startDate]']" ).val(),
                 subType = $form.find( "select[name='ph_subscription[type]']" ).val(),
                 method = $form.find( "input[name='ph_subscription[method]']:checked" ).val(),
                 data = {
@@ -97,11 +95,7 @@
 
             if ('recurring' == subType) {
                 data['interval'] = interval;
-                data['start_date'] = {
-                    "month": startMonth,
-                    "day": startDay,
-                    "year": startYear
-                };
+                data['start_date'] = startDate;
             }
 
             $.ajax({

--- a/docs/source/includes/api/_subscriptions.md
+++ b/docs/source/includes/api/_subscriptions.md
@@ -14,7 +14,7 @@ Based on created subscriptions you can perform purchases (see [Purchase API](#pu
     "amount": 500,
     "currency_code": "USD",
     "interval": "1 month",
-    "start_date": "2017-10-10T00:00:00+00:00",
+    "start_date": "2017-10-15T00:00:00+00:00",
     "type": "recurring",
     "items": [
         {
@@ -82,7 +82,7 @@ amount | int | The amount of the subscription. It needs to be integer value, e.g
 currency_code| string | Three-letter ISO code for currency, e.g. USD, EUR, PLN.
 interval <br>(`optional`)| string | One of `3 months`, `1 month` or `1 year`. The frequency with which a subscription should be billed. `1 month` by default.
 type | string | Subscription type (either `recurring` or `non-recurring`).
-start_date | string | Subscription start date, applies only for recurring subscriptions.
+start_date | string | Subscription start date applies only to recurring subscriptions. Possible values are the 1st day of the current month and year, the 15th day of the current month and year, the 1st day of the next month and current year, the 15th day of the next month and current year. If the current date is lower than the one picked from the dates mentioned above, the API will return 400 status code.
 items | array | An array of subscription items. For more complex subscriptions handling.
 items_total | int | A sum of all items prices.
 total | int | A sum of items total.
@@ -118,11 +118,7 @@ curl -X POST \
       	"currency_code": "USD",
       	"interval": "1 month",
       	"type": "recurring",
-      	"start_date": {
-      	    "day": "10",
-      	    "month": "10",
-      	    "year": "2017"
-      	},
+      	"start_date": "2017-10-15",
       	"method": "directdebit",
         "metadata": {
         	"intention": "bottom_box",
@@ -139,7 +135,7 @@ curl -X POST \
     "amount": 500,
     "currency_code": "USD",
     "interval": "1 month",
-    "start_date": "2017-10-10T00:00:00+00:00",
+    "start_date": "2017-10-15T00:00:00+00:00",
     "type": "recurring",
     "items": [
         {
@@ -210,8 +206,8 @@ amount <br>(`required`)| int | The amount of the subscription. It needs to be in
 currency_code <br>(`required`)| string | The valid currency code, e.g. USD, EUR, PLN.
 interval <br>(`optional`)| string | One of `3 months`, `1 month` or `1 year`. The frequency with which a subscription should be billed. `1 month` by default.
 type <br>(`required`)| string | Subscription type (either `recurring` or `non-recurring`).
-start_date <br>(`required`)| string | Subscription start date, by default current date, applies only for recurring subscriptions.
-method <br>(`required`)| string | Subscription's payment method. A value of payment method's code must be used here, e.g. `directdebit` (see [Payment Methods API](#payment-methods)).
+start_date <br>(`required`)| string | Subscription start date applies only to recurring subscriptions. Possible values are the 1st day of the current month and year, the 15th day of the current month and year, the 1st day of the next month and current year, the 15th day of the next month and current year. If the current date is lower than the one picked from the dates mentioned above, the API will return 400 status code.
+.method <br>(`required`)| string | Subscription's payment method. A value of payment method's code must be used here, e.g. `directdebit` (see [Payment Methods API](#payment-methods)).
 metadata <br>(`optional`)| object | Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.
 
 
@@ -246,7 +242,7 @@ curl -X GET \
     "amount": 500,
     "currency_code": "USD",
     "interval": "1 month",
-    "start_date": "2017-10-10T00:00:00+00:00",
+    "start_date": "2017-10-15T00:00:00+00:00",
     "type": "recurring",
     "items": [
         {
@@ -453,7 +449,7 @@ Returns a list of all subscriptions.
                 "amount": 500,
                 "currency_code": "USD",
                 "interval": "1 month",
-                "start_date": "2017-10-10T00:00:00+00:00",
+                "start_date": "2017-10-15T00:00:00+00:00",
                 "type": "recurring",
                 "items": [
                     {

--- a/docs/source/includes/public_api/_subscriptions.md
+++ b/docs/source/includes/public_api/_subscriptions.md
@@ -13,7 +13,7 @@ Based on created subscriptions you can perform purchases (see [Purchase API](#pu
     "amount": 500,
     "currency_code": "USD",
     "interval": "1 month",
-    "start_date": "2017-11-06T00:00:00+00:00",
+    "start_date": "2017-10-15T00:00:00+00:00",
     "type": "recurring",
     "purchase_completed_at": "2017-11-06T14:14:41+00:00",
     "purchase_state": "completed",
@@ -47,7 +47,7 @@ amount | int | The amount of the subscription. It needs to be integer value, e.g
 currency_code| string | Three-letter ISO code for currency, e.g. USD, EUR, PLN.
 interval <br>(`optional`)| string | One of `3 months`, `1 month` or `1 year`. The frequency with which a subscription should be billed. `1 month` by default.
 type | string | Subscription type (either `recurring` or `non-recurring`).
-start_date | string | Subscription start date, applies only for recurring subscriptions.
+start_date | string | Subscription start date applies only to recurring subscriptions. Possible values are the 1st day of the current month and year, the 15th day of the current month and year, the 1st day of the next month and current year, the 15th day of the next month and current year. If the current date is lower than the one picked from the dates mentioned above, the API will return 400 status code.
 token_value | string | A unique token that is used in payment process.
 purchase_state | string | A state of the checkout process. Can be either: `new`, `payment_selected` or `completed`.
 payment_state | string | A state of the payment. Can be either: `new`, `processing`, `completed`, `failed`, `cancelled` or `refunded`.
@@ -77,11 +77,7 @@ curl -X POST \
       	"currency_code": "USD",
       	"interval": "1 month",
       	"type": "recurring",
-      	"start_date": {
-      	    "day": "10",
-      	    "month": "10",
-      	    "year": "2017"
-      	},
+      	"start_date": "2017-10-15",
       	"method": "directdebit",
         "metadata": {
             "intention": "bottom_box",
@@ -97,7 +93,7 @@ curl -X POST \
     "amount": 500,
     "currency_code": "USD",
     "interval": "1 month",
-    "start_date": "2017-10-10T00:00:00+00:00",
+    "start_date": "2017-10-15T00:00:00+00:00",
     "type": "recurring",
     "purchase_completed_at": "2017-10-10T14:14:41+00:00",
     "purchase_state": "completed",
@@ -133,7 +129,7 @@ amount <br>(`required`)| int | The amount of the subscription. It needs to be in
 currency_code <br>(`required`)| string | The valid currency code, e.g. USD, EUR, PLN.
 interval <br>(`optional`)| string | One of `3 months`, `1 month` or `1 year`. The frequency with which a subscription should be billed. `1 month` by default.
 type <br>(`required`)| string | Subscription type (either `recurring` or `non-recurring`).
-start_date <br>(`required`)| string | Subscription start date, by default current date, applies only for recurring subscriptions.
+start_date | string | Subscription start date applies only to recurring subscriptions. Possible values are the 1st day of the current month and year, the 15th day of the current month and year, the 1st day of the next month and current year, the 15th day of the next month and current year. If the current date is lower than the one picked from the dates mentioned above, the API will return 400 status code.
 method <br>(`required`)| string | Subscription's payment method. A value of payment method's code must be used here, e.g. `directdebit` (see [Payment Methods API](#payment-methods)).
 metadata <br>(`optional`)| object | Set of key/value pairs that you can attach to an object. It can be useful for storing additional information about the object in a structured format.
 

--- a/features/api/payments/validating_metadata_field.feature
+++ b/features/api/payments/validating_metadata_field.feature
@@ -16,11 +16,7 @@ Feature: Validating subscription's metadata
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "10",
-          "year": "2017"
-       },
+      "start_date": "2017-10-15",
       "method": "directdebit",
       "metadata": {
           "intention":"bottom_box",
@@ -48,11 +44,7 @@ Feature: Validating subscription's metadata
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "10",
-          "year": "2017"
-       },
+      "start_date": "2017-10-15",
       "method": "directdebit",
       "metadata": {}
     }
@@ -76,11 +68,7 @@ Feature: Validating subscription's metadata
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "10",
-          "year": "2017"
-       },
+      "start_date": "2017-10-15",
       "method": "directdebit"
     }
     """

--- a/features/api/subscriptions/creating_new_subscriptions.feature
+++ b/features/api/subscriptions/creating_new_subscriptions.feature
@@ -15,11 +15,7 @@ Feature: Creating new subscriptions by admin
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "10",
-          "year": "2017"
-      },
+      "start_date": "2017-10-15",
       "metadata": {
           "intention":"bottom_box",
           "source":"web_version"
@@ -44,11 +40,7 @@ Feature: Creating new subscriptions by admin
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "10",
-          "year": "2017"
-       },
+      "start_date": "2017-10-15",
       "method": "directdebit",
       "metadata": {
           "intention":"bottom_box",
@@ -64,7 +56,7 @@ Feature: Creating new subscriptions by admin
       | currency_code                         | USD                         |
       | amount                                | 500                         |
       | interval                              | month                       |
-      | start_date                            | 2017-10-10T00:00:00+00:00   |
+      | start_date                            | 2017-10-15T00:00:00+00:00   |
       | type                                  | recurring                   |
       | purchase_state                        | completed                   |
       | payment_state                         | awaiting_payment            |

--- a/features/api/subscriptions/prevent_creating_subscription_when_invalid_payment_method.feature
+++ b/features/api/subscriptions/prevent_creating_subscription_when_invalid_payment_method.feature
@@ -16,11 +16,7 @@ Feature: Prevent creating a subscription if a payment method does not support pa
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "10",
-          "year": "2017"
-       },
+      "start_date": "2017-10-10",
        "method": "cash_on_delivery"
     }
     """

--- a/features/api_public/purchases/paying_offline_during_purchase.feature
+++ b/features/api_public/purchases/paying_offline_during_purchase.feature
@@ -50,11 +50,7 @@ Feature: Paying offline for a subscription
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "10",
-          "year": "2017"
-       },
+      "start_date": "2017-10-10",
       "method": "off"
     }
     """

--- a/features/api_public/purchases/paying_using_mbe4_gateway.feature
+++ b/features/api_public/purchases/paying_using_mbe4_gateway.feature
@@ -50,11 +50,7 @@ Feature: Paying for a subscription using Mbe4
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "10",
-          "year": "2017"
-       },
+      "start_date": "2017-10-10",
       "method": "mbe4"
     }
     """

--- a/features/api_public/purchases/paying_using_mollie_gateway.feature
+++ b/features/api_public/purchases/paying_using_mollie_gateway.feature
@@ -49,11 +49,7 @@ Feature: Paying for a subscription using Mollie gateway
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "10",
-          "year": "2017"
-       },
+      "start_date": "2017-10-15",
       "method": "sepa"
     }
     """

--- a/features/api_public/purchases/paying_using_paypal.feature
+++ b/features/api_public/purchases/paying_using_paypal.feature
@@ -49,11 +49,7 @@ Feature: Paying for a subscription using PayPal
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "10",
-          "year": "2017"
-       },
+      "start_date": "2017-10-10",
       "method": "paypal"
     }
     """

--- a/features/api_public/subscriptions/creating_new_subscription.feature
+++ b/features/api_public/subscriptions/creating_new_subscription.feature
@@ -15,11 +15,7 @@ Feature: Creating a new subscription
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "10",
-          "year": "2017"
-       }
+      "start_date": "2017-10-15"
     }
     """
     Then the response status code should be 400
@@ -41,11 +37,7 @@ Feature: Creating a new subscription
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "10",
-          "year": "2017"
-      },
+      "start_date": "2017-10-15",
       "method":"sepa",
       "metadata": {
           "intention":"bottom_box",
@@ -60,7 +52,7 @@ Feature: Creating a new subscription
       | currency_code                         | USD                         |
       | amount                                | 500                         |
       | interval                              | month                       |
-      | start_date                            | 2017-10-10T00:00:00+00:00   |
+      | start_date                            | 2017-10-15T00:00:00+00:00   |
       | type                                  | recurring                   |
       | state                                 | new                         |
       | purchase_state                        | completed                   |

--- a/features/api_public/subscriptions/prevent_to_pay_lower_amount.feature
+++ b/features/api_public/subscriptions/prevent_to_pay_lower_amount.feature
@@ -16,11 +16,7 @@ Feature: Preventing to pay lower amount than the minimum
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "10",
-          "year": "2017"
-       }
+      "start_date": "2017-10-10"
     }
     """
     Then the response status code should be 400

--- a/features/api_public/subscriptions/validating_subscription_start_date.feature
+++ b/features/api_public/subscriptions/validating_subscription_start_date.feature
@@ -15,11 +15,7 @@ Feature: Validating subscription's start date
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "22",
-          "day": "10",
-          "year": "2017"
-       }
+      "start_date": "2017-10-22"
     }
     """
     Then the response status code should be 400
@@ -36,11 +32,7 @@ Feature: Validating subscription's start date
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "9",
-          "year": "2017"
-       }
+      "start_date": "2017-09-10"
     }
     """
     Then the response status code should be 400
@@ -57,11 +49,7 @@ Feature: Validating subscription's start date
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "10",
-          "year": "2018"
-       }
+      "start_date": "2018-10-10"
     }
     """
     Then the response status code should be 400
@@ -79,11 +67,7 @@ Feature: Validating subscription's start date
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "15",
-          "year": "2017"
-       },
+      "start_date": "2017-10-15",
       "method":"sepa"
     }
     """
@@ -102,18 +86,14 @@ Feature: Validating subscription's start date
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "10",
-          "day": "1",
-          "year": "2017"
-       },
+      "start_date": "2017-10-01",
       "method":"sepa"
     }
     """
-    Then the response status code should be 201
+    Then the response status code should be 400
     And the response should be in JSON
 
-  Scenario: Creating new subscription with the upcoming month of the given one in start date
+  Scenario: Creating new subscription with the upcoming month in start date
     Given the system has a payment method "SEPA Direct Debit" with a code "sepa" and a "directdebit" method using Mollie gateway which supports recurring
     When I add "Authorization" header equal to null
     And I add "Content-Type" header equal to "application/json"
@@ -125,18 +105,14 @@ Feature: Validating subscription's start date
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "11",
-          "day": "1",
-          "year": "2017"
-       },
+      "start_date": "2017-11-01",
       "method":"sepa"
     }
     """
     Then the response status code should be 201
     And the response should be in JSON
 
-  Scenario: Creating new subscription with the next month of the upcoming month in start date
+  Scenario: Creating new subscription with the 15th day of upcoming month in start date
     Given the system has a payment method "SEPA Direct Debit" with a code "sepa" and a "directdebit" method using Mollie gateway which supports recurring
     When I add "Authorization" header equal to null
     And I add "Content-Type" header equal to "application/json"
@@ -148,11 +124,7 @@ Feature: Validating subscription's start date
       "currency_code":"USD",
       "interval":"1 month",
       "type":"recurring",
-      "start_date": {
-          "month": "12",
-          "day": "1",
-          "year": "2017"
-       },
+      "start_date": "2017-11-15",
       "method":"sepa"
     }
     """

--- a/src/PH/Behat/Mocks/DateTimeHelperMock.php
+++ b/src/PH/Behat/Mocks/DateTimeHelperMock.php
@@ -11,24 +11,30 @@ final class DateTimeHelperMock implements DateTimeHelperInterface
     /**
      * @inheritdoc}
      */
-    public function getCurrentMonth(int $next = 0): string
+    public function getDate(int $day, int $months = 0): \DateTimeInterface
     {
-        return (string) (10 + $next);
+        $date = new \DateTime(date('2017-10-'.$day));
+
+        if (0 !== $months) {
+            $date->modify(sprintf('+%d months', $months));
+        }
+
+        return $date;
     }
 
     /**
      * @inheritdoc}
      */
-    public function getCurrentDay(): string
+    public function getFormattedDate(int $day, int $months = 0, $format = 'Y-m-d'): string
     {
-        return '10';
+        return $this->getDate($day, $months)->format($format);
     }
 
     /**
      * @inheritdoc}
      */
-    public function getCurrentYear(): string
+    public function getCurrentDateTime(): \DateTimeInterface
     {
-        return '2017';
+        return new \DateTime(date('2017-10-09'));
     }
 }

--- a/src/PH/Bundle/SubscriptionBundle/DependencyInjection/PHSubscriptionExtension.php
+++ b/src/PH/Bundle/SubscriptionBundle/DependencyInjection/PHSubscriptionExtension.php
@@ -20,6 +20,7 @@ final class PHSubscriptionExtension extends AbstractResourceExtension
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $this->registerResources('ph', $config['driver'], $config['resources'], $container);
         $loader->load('forms.yml');
+        $loader->load('services.yml');
 
         $container->setParameter(
             $this->getAlias().'.date_time_helper.class',

--- a/src/PH/Bundle/SubscriptionBundle/Form/Type/StartDateChoiceType.php
+++ b/src/PH/Bundle/SubscriptionBundle/Form/Type/StartDateChoiceType.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PH\Bundle\SubscriptionBundle\Form\Type;
+
+use PH\Bundle\SubscriptionBundle\Provider\StartDateProviderInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class StartDateChoiceType extends AbstractType
+{
+    /**
+     * @var StartDateProviderInterface
+     */
+    private $startDateProvider;
+
+    /**
+     * StartDateChoiceType constructor.
+     *
+     * @param StartDateProviderInterface $startDateProvider
+     */
+    public function __construct(StartDateProviderInterface $startDateProvider)
+    {
+        $this->startDateProvider = $startDateProvider;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver
+            ->setDefaults([
+                'choices' => $this->startDateProvider->getStartDates(),
+            ])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent(): string
+    {
+        return ChoiceType::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix(): string
+    {
+        return 'ph_start_date_choice';
+    }
+}

--- a/src/PH/Bundle/SubscriptionBundle/Form/Type/SubscriptionType.php
+++ b/src/PH/Bundle/SubscriptionBundle/Form/Type/SubscriptionType.php
@@ -4,37 +4,16 @@ declare(strict_types=1);
 
 namespace PH\Bundle\SubscriptionBundle\Form\Type;
 
-use PH\Bundle\SubscriptionBundle\Helper\DateTimeHelperInterface;
 use PH\Component\Subscription\Model\SubscriptionInterface;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
-use Symfony\Component\Form\Extension\Core\Type\DateType;
-use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 final class SubscriptionType extends AbstractResourceType
 {
-    /**
-     * @var DateTimeHelperInterface
-     */
-    private $dateTimeHelper;
-
-    /**
-     * SubscriptionType constructor.
-     *
-     * @param string                  $dataClass
-     * @param array                   $validationGroups
-     * @param DateTimeHelperInterface $dateTimeHelper
-     */
-    public function __construct($dataClass, $validationGroups = [], DateTimeHelperInterface $dateTimeHelper)
-    {
-        parent::__construct($dataClass, $validationGroups);
-
-        $this->dateTimeHelper = $dateTimeHelper;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -58,17 +37,20 @@ final class SubscriptionType extends AbstractResourceType
                     'Recurring' => SubscriptionInterface::TYPE_RECURRING,
                 ],
             ])
-            ->add('startDate', DateType::class, [
-                'widget' => 'choice',
-                'days' => [$this->dateTimeHelper->getCurrentDay(), 1, 15],
-                'years' => [$this->dateTimeHelper->getCurrentYear()],
-                'months' => [
-                    $this->dateTimeHelper->getCurrentMonth(),
-                    $this->dateTimeHelper->getCurrentMonth(1),
-                    $this->dateTimeHelper->getCurrentMonth(2),
-                ],
-                'data' => new \DateTime(),
-            ])
+            ->add('startDate', StartDateChoiceType::class)
+        ;
+
+        $builder->get('startDate')
+            ->addModelTransformer(new CallbackTransformer(
+                function ($value) {
+                    return $value;
+                },
+                function ($value) {
+                    if (is_string($value)) {
+                        return new \DateTime($value);
+                    }
+                }
+            ))
         ;
     }
 

--- a/src/PH/Bundle/SubscriptionBundle/Helper/DateTimeHelper.php
+++ b/src/PH/Bundle/SubscriptionBundle/Helper/DateTimeHelper.php
@@ -9,24 +9,22 @@ final class DateTimeHelper implements DateTimeHelperInterface
     /**
      * @inheritdoc}
      */
-    public function getCurrentMonth(int $next = 0): string
+    public function getDate(int $day, int $months = 0): \DateTimeInterface
     {
-        return (string) ((int) date('m') + $next);
+        $date = new \DateTime(date('Y-m-'.$day));
+
+        if (0 !== $months) {
+            $date->modify(sprintf('+%d months', $months));
+        }
+
+        return $date;
     }
 
     /**
      * @inheritdoc}
      */
-    public function getCurrentDay(): string
+    public function getFormattedDate(int $day, int $months = 0, $format = 'Y-m-d'): string
     {
-        return date('d');
-    }
-
-    /**
-     * @inheritdoc}
-     */
-    public function getCurrentYear(): string
-    {
-        return date('Y');
+        return $this->getDate($day, $months)->format($format);
     }
 }

--- a/src/PH/Bundle/SubscriptionBundle/Helper/DateTimeHelper.php
+++ b/src/PH/Bundle/SubscriptionBundle/Helper/DateTimeHelper.php
@@ -27,4 +27,12 @@ final class DateTimeHelper implements DateTimeHelperInterface
     {
         return $this->getDate($day, $months)->format($format);
     }
+
+    /**
+     * @inheritdoc}
+     */
+    public function getCurrentDate(): \DateTimeInterface
+    {
+        return new \DateTime();
+    }
 }

--- a/src/PH/Bundle/SubscriptionBundle/Helper/DateTimeHelper.php
+++ b/src/PH/Bundle/SubscriptionBundle/Helper/DateTimeHelper.php
@@ -31,7 +31,7 @@ final class DateTimeHelper implements DateTimeHelperInterface
     /**
      * @inheritdoc}
      */
-    public function getCurrentDate(): \DateTimeInterface
+    public function getCurrentDateTime(): \DateTimeInterface
     {
         return new \DateTime();
     }

--- a/src/PH/Bundle/SubscriptionBundle/Helper/DateTimeHelperInterface.php
+++ b/src/PH/Bundle/SubscriptionBundle/Helper/DateTimeHelperInterface.php
@@ -22,4 +22,9 @@ interface DateTimeHelperInterface
      * @return string
      */
     public function getFormattedDate(int $day, int $months = 0, $format = 'Y-m-d'): string;
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getCurrentDateTime(): \DateTimeInterface;
 }

--- a/src/PH/Bundle/SubscriptionBundle/Helper/DateTimeHelperInterface.php
+++ b/src/PH/Bundle/SubscriptionBundle/Helper/DateTimeHelperInterface.php
@@ -7,19 +7,19 @@ namespace PH\Bundle\SubscriptionBundle\Helper;
 interface DateTimeHelperInterface
 {
     /**
-     * @param int $next
+     * @param int $day
+     * @param int $months
+     *
+     * @return \DateTimeInterface
+     */
+    public function getDate(int $day, int $months = 0): \DateTimeInterface;
+
+    /**
+     * @param int    $day
+     * @param int    $months
+     * @param string $format
      *
      * @return string
      */
-    public function getCurrentMonth(int $next = 0): string;
-
-    /**
-     * @return string
-     */
-    public function getCurrentDay(): string;
-
-    /**
-     * @return string
-     */
-    public function getCurrentYear(): string;
+    public function getFormattedDate(int $day, int $months = 0, $format = 'Y-m-d'): string;
 }

--- a/src/PH/Bundle/SubscriptionBundle/Provider/StartDateProvider.php
+++ b/src/PH/Bundle/SubscriptionBundle/Provider/StartDateProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PH\Bundle\SubscriptionBundle\Provider;
+
+use PH\Bundle\SubscriptionBundle\Helper\DateTimeHelperInterface;
+
+final class StartDateProvider implements StartDateProviderInterface
+{
+    private $dateTimeHelper;
+
+    public function __construct(DateTimeHelperInterface $dateTimeHelper)
+    {
+        $this->dateTimeHelper = $dateTimeHelper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStartDates(): array
+    {
+        $now = new \DateTime();
+        $dates = [];
+
+        if ($now < $this->dateTimeHelper->getDate(1)) {
+            $dates[$this->dateTimeHelper->getFormattedDate(1)] = $this->dateTimeHelper->getFormattedDate(1);
+        }
+
+        if ($now < $this->dateTimeHelper->getDate(15)) {
+            $dates[$this->dateTimeHelper->getFormattedDate(15)] = $this->dateTimeHelper->getFormattedDate(15);
+        }
+
+        return array_merge($dates, [
+            $this->dateTimeHelper->getFormattedDate(1, 1) => $this->dateTimeHelper->getFormattedDate(1, 1),
+            $this->dateTimeHelper->getFormattedDate(15, 1) => $this->dateTimeHelper->getFormattedDate(15, 1),
+        ]);
+    }
+}

--- a/src/PH/Bundle/SubscriptionBundle/Provider/StartDateProvider.php
+++ b/src/PH/Bundle/SubscriptionBundle/Provider/StartDateProvider.php
@@ -20,7 +20,7 @@ final class StartDateProvider implements StartDateProviderInterface
      */
     public function getStartDates(): array
     {
-        $now = new \DateTime();
+        $now = $this->dateTimeHelper->getCurrentDateTime();
         $dates = [];
 
         if ($now < $this->dateTimeHelper->getDate(1)) {

--- a/src/PH/Bundle/SubscriptionBundle/Provider/StartDateProviderInterface.php
+++ b/src/PH/Bundle/SubscriptionBundle/Provider/StartDateProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PH\Bundle\SubscriptionBundle\Provider;
+
+interface StartDateProviderInterface
+{
+    /**
+     * @return array
+     */
+    public function getStartDates(): array;
+}

--- a/src/PH/Bundle/SubscriptionBundle/Resources/config/forms.yml
+++ b/src/PH/Bundle/SubscriptionBundle/Resources/config/forms.yml
@@ -4,6 +4,12 @@ services:
         arguments:
             - '%ph.model.subscription.class%'
             - ['ph']
-            - '@ph.helper.date_time' # registered by compiler pass
+        tags:
+            - { name: form.type }
+
+    ph.form.type.start_date_choice:
+        class: PH\Bundle\SubscriptionBundle\Form\Type\StartDateChoiceType
+        arguments:
+            - '@ph.provider.start_date'
         tags:
             - { name: form.type }

--- a/src/PH/Bundle/SubscriptionBundle/Resources/config/services.yml
+++ b/src/PH/Bundle/SubscriptionBundle/Resources/config/services.yml
@@ -1,0 +1,5 @@
+services:
+    ph.provider.start_date:
+        class: PH\Bundle\SubscriptionBundle\Provider\StartDateProvider
+        arguments:
+            - '@ph.helper.date_time'


### PR DESCRIPTION
- [x] - removed current date from start date and refactored the way the start date is handled in the Subscription API  
- [x] - BC - start date is now accepted as a string value in the Subscriptions API, e.g. `2017-11-09` and not as an object (see below).
```json
        "start_date": {
            "day": "10",
            "month: "10",
            "year": "2017"
        }
```
- [x] - docs
- [x] - tests